### PR TITLE
fix: resolve 19 Dependabot alerts (electron, follow-redirects)

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -35,6 +35,12 @@
     "minimatch@<3.1.4": "3.1.4",
     "minimatch@>=9.0.0 <9.0.7": "9.0.7",
     "cross-spawn@<6.0.6": "6.0.6",
-    "got@<11.8.5": "11.8.5"
+    "got@<11.8.5": "11.8.5",
+    "electron": ">=39.8.5",
+    "follow-redirects": ">=1.16.0"
+  },
+  "resolutions": {
+    "electron": ">=39.8.5",
+    "follow-redirects": ">=1.16.0"
   }
 }

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -906,10 +906,17 @@
   resolved "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz"
   integrity sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==
 
-"@types/node@*", "@types/node@^16.11.26":
+"@types/node@*":
   version "16.18.98"
   resolved "https://registry.npmjs.org/@types/node/-/node-16.18.98.tgz"
   integrity sha512-fpiC20NvLpTLAzo3oVBKIqBGR6Fx/8oAK/SSf7G+fydnXMY1x4x9RZ6sBXhqKlCU21g2QapUsbLlhv3+a7wS+Q==
+
+"@types/node@^24.9.0":
+  version "24.12.2"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-24.12.2.tgz#353cb161dbf1785ea25e8829ba7ec574c5c629ac"
+  integrity sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==
+  dependencies:
+    undici-types "~7.16.0"
 
 "@types/parse-json@^4.0.0":
   version "4.0.2"
@@ -2158,13 +2165,13 @@ electron-to-chromium@^1.5.263:
   resolved "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.321.tgz"
   integrity sha512-L2C7Q279W2D/J4PLZLk7sebOILDSWos7bMsMNN06rK482umHUrh/3lM8G7IlHFOYip2oAg5nha1rCMxr/rs6ZQ==
 
-electron@^23.1.2:
-  version "23.3.13"
-  resolved "https://registry.npmjs.org/electron/-/electron-23.3.13.tgz"
-  integrity sha512-BaXtHEb+KYKLouUXlUVDa/lj9pj4F5kiE0kwFdJV84Y2EU7euIDgPthfKtchhr5MVHmjtavRMIV/zAwEiSQ9rQ==
+electron@>=39.8.5, electron@^23.1.2:
+  version "41.2.0"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-41.2.0.tgz#7598019461b3cde346a9d59cc6ba11229d7717f0"
+  integrity sha512-0OKLiymqfV0WK68RBXqAm3Myad2TpI5wwxLCBEUcH5Nugo3YfSk7p1Js/AL9266qTz5xZioUnxt9hG8FFwax0g==
   dependencies:
     "@electron/get" "^2.0.0"
-    "@types/node" "^16.11.26"
+    "@types/node" "^24.9.0"
     extract-zip "^2.0.1"
 
 encodeurl@~2.0.0:
@@ -2707,10 +2714,10 @@ flatted@^3.2.9:
   resolved "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz"
   integrity sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==
 
-follow-redirects@^1.0.0:
-  version "1.15.11"
-  resolved "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz"
-  integrity sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==
+follow-redirects@>=1.16.0, follow-redirects@^1.0.0:
+  version "1.16.0"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.16.0.tgz#28474a159d3b9d11ef62050a14ed60e4df6d61bc"
+  integrity sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==
 
 for-each@^0.3.3, for-each@^0.3.5:
   version "0.3.5"
@@ -5380,6 +5387,11 @@ unbox-primitive@^1.1.0:
     has-bigints "^1.0.2"
     has-symbols "^1.1.0"
     which-boxed-primitive "^1.1.1"
+
+undici-types@~7.16.0:
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-7.16.0.tgz#ffccdff36aea4884cbfce9a750a0580224f58a46"
+  integrity sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==
 
 unique-string@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
## Summary
- `web/yarn.lock` の Dependabot alerts 19 件を解消
- いずれも devDependency 経由の推移的依存 (production ビルド非搭載)

## 修正内容
`web/package.json` の `overrides` / `resolutions` にバージョン下限を追加し、`yarn install` で lockfile を再生成。

| Package | Old | New | 経由 | Alerts |
|---|---|---|---|---|
| electron | 23.3.13 | 41.2.0 | react-devtools | #29, #68, #70, #110-125 |
| follow-redirects | 1.15.11 | 1.16.0 | webpack-dev-server | #129 |

## Test plan
- [ ] `yarn install` が成功する
- [ ] `yarn build` が成功する
- [ ] マージ後 Dependabot alerts が close される

🤖 Generated with [Claude Code](https://claude.com/claude-code)