### PR TITLE
fix: resolve Dependabot security alerts (qs, uuid, webpack-dev-server)

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -25,7 +25,7 @@
     "typescript": "^5.4.5",
     "webpack": "^5.104.1",
     "webpack-cli": "^5.1.4",
-    "webpack-dev-server": "^5.2.3"
+    "webpack-dev-server": "^5.2.4"
   },
   "scripts": {
     "start": "npx webpack serve",
@@ -37,10 +37,14 @@
     "cross-spawn@<6.0.6": "6.0.6",
     "got@<11.8.5": "11.8.5",
     "electron": ">=39.8.5",
-    "follow-redirects": ">=1.16.0"
+    "follow-redirects": ">=1.16.0",
+    "qs": ">=6.15.2",
+    "uuid": ">=11.1.1"
   },
   "resolutions": {
     "electron": ">=39.8.5",
-    "follow-redirects": ">=1.16.0"
+    "follow-redirects": ">=1.16.0",
+    "qs": ">=6.15.2",
+    "uuid": ">=11.1.1"
   }
 }

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -4381,10 +4381,10 @@ pvutils@^1.1.3:
   resolved "https://registry.npmjs.org/pvutils/-/pvutils-1.1.5.tgz"
   integrity sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA==
 
-qs@~6.14.0:
-  version "6.14.2"
-  resolved "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz"
-  integrity sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==
+qs@>=6.15.2, qs@~6.14.0:
+  version "6.15.2"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.15.2.tgz#fd55426d710403ddccc45e0f9eab16db7727ece9"
+  integrity sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==
   dependencies:
     side-channel "^1.1.0"
 
@@ -5468,10 +5468,10 @@ utils-merge@1.0.1:
   resolved "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz"
   integrity sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==
 
-uuid@^8.3.2:
-  version "8.3.2"
-  resolved "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz"
-  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
+uuid@>=11.1.1, uuid@^8.3.2:
+  version "14.0.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-14.0.0.tgz#0af883220163d264ffe0c084f6b8a89b9666966d"
+  integrity sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==
 
 vary@~1.1.2:
   version "1.1.2"
@@ -5524,10 +5524,10 @@ webpack-dev-middleware@^7.4.2:
     range-parser "^1.2.1"
     schema-utils "^4.0.0"
 
-webpack-dev-server@^5.2.3:
-  version "5.2.3"
-  resolved "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.3.tgz"
-  integrity sha512-9Gyu2F7+bg4Vv+pjbovuYDhHX+mqdqITykfzdM9UyKqKHlsE5aAjRhR+oOEfXW5vBeu8tarzlJFIZva4ZjAdrQ==
+webpack-dev-server@^5.2.4:
+  version "5.2.4"
+  resolved "https://registry.yarnpkg.com/webpack-dev-server/-/webpack-dev-server-5.2.4.tgz#6e6306ce59848ed322c235e48b326632b1eed6d6"
+  integrity sha512-GqDPGZN9bRqKBTkp4aWkobDDHMsrXKoGSdOH56smIri8qR0JG8gfL8/v/f/OZR3/OKXjG8uwJbFVhKm/FNU/UA==
   dependencies:
     "@types/bonjour" "^3.5.13"
     "@types/connect-history-api-fallback" "^1.5.4"


### PR DESCRIPTION
## Summary
- Dependabot alerts で検出された 3 件のセキュリティ脆弱性を修正
- 3 件はいずれも `web/yarn.lock` の **development scope**（`webpack-dev-server` 配下の直接/推移的依存）で、本番ビルド成果物には含まれない

## 修正内容
| Alert # | Package | Old | New | CVE | Severity |
|---------|---------|-----|-----|-----|----------|
| #132 | webpack-dev-server | 5.2.3 | 5.2.4 | CVE-2026-6402 | moderate |
| #134 | qs | 6.14.2 | 6.15.2 | CVE-2026-8723 | moderate |
| #133 | uuid | 8.3.2 | 14.0.0 | CVE-2026-41907 | moderate |

## 修正方針
- **webpack-dev-server**: 直接 devDependency を `^5.2.4` に更新（パッチ）
- **qs**: express が `~6.14.0` で制約しており通常解決では patched 6.15.2 に到達できないため、既存方式に倣い `resolutions`/`overrides` で `>=6.15.2` を固定
- **uuid**: sockjs 経由の推移的依存。`resolutions`/`overrides` で `>=11.1.1` を固定（14.0.0 に解決）。sockjs は `require('uuid').v4` のみ使用しており v14 でも動作することを確認

## テスト
- [x] 依存関係の整合性確認済み（`yarn why` で解決バージョン確認）
- [x] `require('uuid').v4` / sockjs ロード確認
- [x] `yarn build`（本番ビルド）成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)